### PR TITLE
Added explicit nullable type.

### DIFF
--- a/src/Rest/HttpExchangeFormatter.php
+++ b/src/Rest/HttpExchangeFormatter.php
@@ -11,7 +11,7 @@ class HttpExchangeFormatter
 
     private $response;
 
-    public function __construct(RequestInterface $request = null, ResponseInterface $response = null)
+    public function __construct(?RequestInterface $request = null, ?ResponseInterface $response = null)
     {
         $this->request = $request;
         $this->response = $response;

--- a/src/Rest/RestApiBrowser.php
+++ b/src/Rest/RestApiBrowser.php
@@ -40,7 +40,7 @@ class RestApiBrowser
     /**
      * @param string $host
      */
-    public function __construct($host, ClientInterface $httpClient = null)
+    public function __construct($host, ?ClientInterface $httpClient = null)
     {
         $this->host = $host;
         $this->httpClient = $httpClient ?: Psr18ClientDiscovery::find();


### PR DESCRIPTION
PHP 8.4 deprecates implicitly marking function arguments as nullable.

```
Deprecated: Ubirak\RestApiBehatExtension\Rest\HttpExchangeFormatter::__construct(): Implicitly marking parameter $request as nullable is deprecated, the explicit nullable type must be used instead in /app/vendor/ubirak/rest-api-behat-extension/src/Rest/HttpExchangeFormatter.php line 14
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adopted nullable type hints in constructors for HTTP exchange formatting and REST API browser components. This clarifies intent, improves type safety, and enhances IDE/static analysis support while maintaining existing behavior when no client or messages are provided. No functional changes or breaking changes for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->