### PR TITLE
Added back support for Symfony 6.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,10 @@
         "php-http/message": "^1.11",
         "php-http/message-factory": "^1.1",
         "psr/http-message": "^2.0",
-        "symfony/config": "^7.0",
-        "symfony/dependency-injection": "^7.0",
-        "symfony/http-foundation": "^7.0",
-        "symfony/property-access": "^7.0",
+        "symfony/config": "^6.4 || ^7.0",
+        "symfony/dependency-injection": "^6.4 || ^7.0",
+        "symfony/http-foundation": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
         "tolerance/tolerance": "^0.4.2"
     },
     "require-dev": {


### PR DESCRIPTION
Closes #12 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened Symfony package compatibility to accept 6.4 alongside 7.x for several core Symfony packages, enabling broader deployment flexibility across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->