### PR TITLE
[#13] Replaced deprecated `php-http/message-factory` with `psr/http-factory`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php-http/client-common": "^2.3",
         "php-http/discovery": "^1.13",
         "php-http/message": "^1.11",
-        "php-http/message-factory": "^1.1",
+        "psr/http-factory": "^1.0",
         "psr/http-message": "^2.0",
         "symfony/config": "^6.4 || ^7.0",
         "symfony/dependency-injection": "^6.4 || ^7.0",

--- a/tests/Units/Rest/RestApiBrowser.php
+++ b/tests/Units/Rest/RestApiBrowser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Ubirak\RestApiBehatExtension\Tests\Units\Rest;
 
 use Http\Mock\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use GuzzleHttp\Psr7\HttpFactory;
 use atoum;
 use Ubirak\RestApiBehatExtension\Rest\RestApiBrowser as SUT;
 
@@ -171,21 +171,18 @@ class RestApiBrowser extends atoum
 
     /**
      * @param string $baseUrl
-     * @param int    $responseStatusCode
      *
      * @return \Ivory\HttpAdapter\HttpAdapterInterface
      */
-    private function mockHttpClient($responseStatusCode, array $headers = []): Client
+    private function mockHttpClient(int $responseStatusCode, array $headers = []): Client
     {
         $mockHttpClient = new Client();
-        $messageFactory = new GuzzleMessageFactory();
-        $mockHttpClient->addResponse(
-            $messageFactory->createResponse(
-                $responseStatusCode,
-                null,
-                $headers
-            )
-        );
+        $response_factory = new HttpFactory();
+        $response = $response_factory->createResponse($responseStatusCode);
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+        $mockHttpClient->addResponse($response);
 
         return $mockHttpClient;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Replaced deprecated `php-http/message-factory` with `psr/http-factory` (Issue #13)

### Changes Made

**Dependency Update (composer.json):**
- Removed: `php-http/message-factory` ^1.1 from `require` block
- Added: `psr/http-factory` ^1.0 to `require` block

This change migrates the HTTP factory dependency from a legacy factory abstraction to the PSR-17 HTTP factory standard, improving compatibility with modern PHP HTTP standards.

**Test Updates (tests/Units/Rest/RestApiBrowser.php):**
- Updated HTTP response construction logic: replaced `GuzzleMessageFactory` with `GuzzleHttp\Psr7\HttpFactory`
- Changed response header application: headers are now applied via explicit `withHeader()` iteration instead of being passed directly to the factory constructor
- Improved type safety: `mockHttpClient()` method now includes return type `Client` and parameter type hint `int` for `$responseStatusCode`
- Updated import statements to reflect the new factory implementation

The changes modernize the codebase to use PSR-17 factory abstraction while maintaining backward compatibility and improving type safety in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->